### PR TITLE
Adding update (-u) option to go get in requirements installment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,14 +4,14 @@ get-test:
 	@/bin/echo "Installing test dependencies... "
 	@go list -f '{{range .TestImports}}{{.}} {{end}}' ./... | tr ' ' '\n' |\
 		grep '^.*\..*/.*$$' | grep -v 'github.com/globocom/gandalf' |\
-		sort | uniq | xargs go get >/dev/null 2>&1
+		sort | uniq | xargs go get -u >/dev/null 2>&1
 	@/bin/echo "ok"
 
 get-prod:
 	@/bin/echo "Installing production dependencies... "
 	@go list -f '{{range .Imports}}{{.}} {{end}}' ./... | tr ' ' '\n' |\
 		grep '^.*\..*/.*$$' | grep -v 'github.com/globocom/gandalf' |\
-		sort | uniq | xargs go get >/dev/null 2>&1
+		sort | uniq | xargs go get -u >/dev/null 2>&1
 	@/bin/echo "ok"
 
 test:


### PR DESCRIPTION
I had some troubles with outdated requirements and forcing `go get` to update the packages seems to fix this. I think it's a good default behavior so I added it to the `Makefile`.
