### PR TITLE
Allow empty message (no content) when committing

### DIFF
--- a/repository/mocks.go
+++ b/repository/mocks.go
@@ -100,7 +100,7 @@ func CreateTestRepository(tmp_path string, repo string, file string, content str
 	if err != nil {
 		return cleanup, err
 	}
-	cmd = exec.Command(gitPath, "commit", "-m", content)
+	cmd = exec.Command(gitPath, "commit", "-m", content, "--allow-empty-message")
 	cmd.Dir = testPath
 	err = cmd.Run()
 	return cleanup, err

--- a/repository/repository_test.go
+++ b/repository/repository_test.go
@@ -538,6 +538,23 @@ func (s *S) TestGetFileContentIntegration(c *gocheck.C) {
 	c.Assert(string(contents), gocheck.Equals, content)
 }
 
+func (s *S) TestGetFileContentIntegrationEmptyContent(c *gocheck.C) {
+	oldBare := bare
+	bare = "/tmp"
+	repo := "gandalf-test-repo"
+	file := "README"
+	content := ""
+	cleanUp, errCreate := CreateTestRepository(bare, repo, file, content)
+	defer func() {
+		cleanUp()
+		bare = oldBare
+	}()
+	c.Assert(errCreate, gocheck.IsNil)
+	contents, err := GetFileContents(repo, "master", file)
+	c.Assert(err, gocheck.IsNil)
+	c.Assert(string(contents), gocheck.Equals, content)
+}
+
 func (s *S) TestGetFileContentWhenRefIsInvalid(c *gocheck.C) {
 	oldBare := bare
 	bare = "/tmp"
@@ -576,6 +593,24 @@ func (s *S) TestGetTreeIntegration(c *gocheck.C) {
 	repo := "gandalf-test-repo"
 	file := "README"
 	content := "much WOW"
+	cleanUp, errCreate := CreateTestRepository(bare, repo, file, content, "such", "folder", "much", "magic")
+	defer func() {
+		cleanUp()
+		bare = oldBare
+	}()
+	c.Assert(errCreate, gocheck.IsNil)
+	tree, err := GetTree(repo, "master", "much/README")
+	c.Assert(err, gocheck.IsNil)
+	c.Assert(tree[0]["path"], gocheck.Equals, "much/README")
+	c.Assert(tree[0]["rawPath"], gocheck.Equals, "much/README")
+}
+
+func (s *S) TestGetTreeIntegrationEmptyContent(c *gocheck.C) {
+	oldBare := bare
+	bare = "/tmp"
+	repo := "gandalf-test-repo"
+	file := "README"
+	content := ""
 	cleanUp, errCreate := CreateTestRepository(bare, repo, file, content, "such", "folder", "much", "magic")
 	defer func() {
 		cleanUp()


### PR DESCRIPTION
Update `CreateTestRepository()` method to allow empty content as commit message.
