### PR TITLE
Warily treat empty or invalid pattern (re #120 and #123)

### DIFF
--- a/repository/repository.go
+++ b/repository/repository.go
@@ -369,6 +369,11 @@ func (*GitContentRetriever) GetForEachRef(repo, pattern string) ([]map[string]st
 		return nil, fmt.Errorf("Error when trying to obtain the refs of repository %s (%s).", repo, err)
 	}
 	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
+	// When the separator does not separate the string, Split returns an array
+	// with one element: the string itself. (golang.org/pkg/strings/#Split)
+	if len(lines) == 1 && len(lines[0]) == 0 {
+		return nil, nil
+	}
 	objectCount := len(lines)
 	objects := make([]map[string]string, objectCount)
 	objectCount = 0

--- a/repository/repository_test.go
+++ b/repository/repository_test.go
@@ -909,3 +909,37 @@ func (s *S) TestGetForEachRefIntegrationSubjectWithTab(c *gocheck.C) {
 	c.Assert(refs[1]["authorEmail"], gocheck.Equals, "<much@email.com>")
 	c.Assert(refs[1]["subject"], gocheck.Equals, "will\tbark")
 }
+
+func (s *S) TestGetForEachRefIntegrationWhenPatternEmpty(c *gocheck.C) {
+	oldBare := bare
+	bare = "/tmp"
+	repo := "gandalf-test-repo"
+	file := "README"
+	content := "much WOW"
+	cleanUp, errCreate := CreateTestRepository(bare, repo, file, content)
+	defer func() {
+		cleanUp()
+		bare = oldBare
+	}()
+	c.Assert(errCreate, gocheck.IsNil)
+	refs, err := GetForEachRef("gandalf-test-repo", "")
+	c.Assert(refs, gocheck.IsNil)
+	c.Assert(err, gocheck.IsNil)
+}
+
+func (s *S) TestGetForEachRefIntegrationWhenPatternInvalid(c *gocheck.C) {
+	oldBare := bare
+	bare = "/tmp"
+	repo := "gandalf-test-repo"
+	file := "README"
+	content := "much WOW"
+	cleanUp, errCreate := CreateTestRepository(bare, repo, file, content)
+	defer func() {
+		cleanUp()
+		bare = oldBare
+	}()
+	c.Assert(errCreate, gocheck.IsNil)
+	refs, err := GetForEachRef("gandalf-test-repo", "invalid_pattern")
+	c.Assert(refs, gocheck.IsNil)
+	c.Assert(err, gocheck.IsNil)
+}


### PR DESCRIPTION
Let the user supply an empty or invalid pattern if she chooses to do so
