### PR TITLE
Add handler for `GET /repository/repo/branch` (fix #123)

### DIFF
--- a/api/handler.go
+++ b/api/handler.go
@@ -333,3 +333,25 @@ func GetTree(w http.ResponseWriter, r *http.Request) {
 	}
 	w.Write(b)
 }
+
+func GetBranch(w http.ResponseWriter, r *http.Request) {
+	repo := r.URL.Query().Get(":name")
+	if repo == "" {
+		err := fmt.Errorf("Error when trying to obtain the branches of repository %s (repository is required).", repo)
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	branches, err := repository.GetBranch(repo)
+	if err != nil {
+		err := fmt.Errorf("Error when trying to obtain the branches of repository %s (%s).", repo, err)
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	b, err := json.Marshal(branches)
+	if err != nil {
+		err := fmt.Errorf("Error when trying to obtain the branches of repository %s (%s).", repo, err)
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	w.Write(b)
+}

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -129,3 +129,20 @@ Example URLs (http://gandalf-server omitted for clarity)::
     $ curl /repository/myrepository/archive/master.zip        # gets master and zip format
     $ curl /repository/myrepository/archive/master.tar.gz     # gets master and tar.gz format
     $ curl /repository/myrepository/archive/0.1.0.zip         # gets 0.1.0 tag and zip format
+
+Get branch
+-----------
+
+Returns a list of all the branches of the specified `repository`.
+
+* Method: GET
+* URI: /repository/`:name`/branch
+* Format: JSON
+
+Where:
+
+* `:name` is the name of the repository.
+
+Example URL (http://gandalf-server omitted for clarity)::
+
+    $ curl /repository/myrepository/branch                    # gets list of branches

--- a/webserver/main.go
+++ b/webserver/main.go
@@ -49,6 +49,7 @@ For an example conf check gandalf/etc/gandalf.conf file.\n %s`
 	router.Get("/repository/:name/contents", http.HandlerFunc(api.GetFileContents))
 	router.Get("/repository/:name/tree/:path", http.HandlerFunc(api.GetTree))
 	router.Get("/repository/:name/tree", http.HandlerFunc(api.GetTree))
+	router.Get("/repository/:name/branch", http.HandlerFunc(api.GetTree))
 	router.Get("/healthcheck/", http.HandlerFunc(api.HealthCheck))
 	router.Post("/hook/:name", http.HandlerFunc(api.AddHook))
 


### PR DESCRIPTION
Tests were named like that (`TestGetBranch`, `TestGetBranchWhenRepoNotSupplied`, `TestGetBranchWhenRepoNonExistent` and `TestGetBranchWhenCommandFails`) to gain on such calls:

```
$ cd api/
$ go test -gocheck.f TestGetBranch ./...
OK: 4 passed
PASS
ok      github.com/tsuru/gandalf/api    0.167s
```

```
$ cd api/
$ go test -gocheck.f TestGetBranchWhen ./...
OK: 3 passed
PASS
ok      github.com/tsuru/gandalf/api    0.158s
```

```
$ cd api/
$ go test -gocheck.f TestGetBranchWhenRepoNo ./...
OK: 2 passed
PASS
ok      github.com/tsuru/gandalf/api    0.126s
```

```
$ cd api/
$ go test -gocheck.f TestGetBranchWhenRepoNon ./...
OK: 1 passed
PASS
ok      github.com/tsuru/gandalf/api    0.129s
```
