### PR TITLE
Fix Travis CI build for forks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ go:
 before_install:
   - sudo apt-get update -qq
   - sudo apt-get install mercurial bzr -qq
+  - find . -type f -iname *json -exec sed -r -i "s|\"github.com/tsuru/gandalf(/[a-z]+)?\"|\"github.com/$TRAVIS_REPO_SLUG\1\"|" {} + -print
+  - find . -type f -iname *go -exec sed -r -i "s|\"github.com/tsuru/gandalf(/[a-z]+)?\"|\"github.com/$TRAVIS_REPO_SLUG\1\"|" {} + -print
 install:
   - export PATH="$HOME/gopath/bin:$PATH"
   - make get


### PR DESCRIPTION
Replace the source used to get and import Gandalf with that of the current repository

Not really sure why `find . -type f -iname *json -o -iname *go ...` does not work as I'd expect, any insight on that is very, very welcome.

Nonetheless, I can now happily push to my fork and let Travis CI green it for me :wink: YAY!
