### PR TITLE
Modified parameters for the route archive to be passed by querystring

### DIFF
--- a/api/handler_test.go
+++ b/api/handler_test.go
@@ -974,8 +974,8 @@ func (s *S) TestGetTreeWhenCommandFails(c *gocheck.C) {
 
 func (s *S) TestGetBranch(c *gocheck.C) {
 	url := "/repository/repo/branch?:name=repo"
-	refs := make([]map[string]string, 1)
-	refs[0] = make(map[string]string)
+	refs := make([]map[string]interface{}, 1)
+	refs[0] = map[string]interface{}{}
 	refs[0]["ref"] = "a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9"
 	refs[0]["name"] = "doge_barks"
 	refs[0]["commiterName"] = "doge"
@@ -983,6 +983,10 @@ func (s *S) TestGetBranch(c *gocheck.C) {
 	refs[0]["authorName"] = "doge"
 	refs[0]["authorEmail"] = "<much@email.com>"
 	refs[0]["subject"] = "will bark"
+	links := map[string]string{}
+	links["zipArchive"] = repository.GetArchiveUrl("repo", "doge_barks", "zip")
+	links["tarArchive"] = repository.GetArchiveUrl("repo", "doge_barks", "tar.gz")
+	refs[0]["_links"] = links
 	mockRetriever := repository.MockContentRetriever{
 		Refs: refs,
 	}
@@ -995,7 +999,7 @@ func (s *S) TestGetBranch(c *gocheck.C) {
 	recorder := httptest.NewRecorder()
 	GetBranch(recorder, request)
 	c.Assert(recorder.Code, gocheck.Equals, http.StatusOK)
-	var obj []map[string]string
+	var obj []map[string]interface{}
 	json.Unmarshal(recorder.Body.Bytes(), &obj)
 	c.Assert(len(obj), gocheck.Equals, 1)
 	c.Assert(obj[0]["ref"], gocheck.Equals, refs[0]["ref"])
@@ -1005,6 +1009,9 @@ func (s *S) TestGetBranch(c *gocheck.C) {
 	c.Assert(obj[0]["authorName"], gocheck.Equals, refs[0]["authorName"])
 	c.Assert(obj[0]["authorEmail"], gocheck.Equals, refs[0]["authorEmail"])
 	c.Assert(obj[0]["subject"], gocheck.Equals, refs[0]["subject"])
+	objLinks := obj[0]["_links"].(map[string]interface{})
+	c.Assert(objLinks["zipArchive"], gocheck.Equals, links["zipArchive"])
+	c.Assert(objLinks["tarArchive"], gocheck.Equals, links["tarArchive"])
 }
 
 func (s *S) TestGetBranchWhenRepoNotSupplied(c *gocheck.C) {
@@ -1049,8 +1056,8 @@ func (s *S) TestGetBranchWhenCommandFails(c *gocheck.C) {
 
 func (s *S) TestGetTag(c *gocheck.C) {
 	url := "/repository/repo/tag?:name=repo"
-	tags := make([]map[string]string, 1)
-	tags[0] = make(map[string]string)
+	tags := make([]map[string]interface{}, 1)
+	tags[0] = map[string]interface{}{}
 	tags[0]["ref"] = "a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9"
 	tags[0]["name"] = "0.1"
 	tags[0]["commiterName"] = "doge"
@@ -1058,6 +1065,10 @@ func (s *S) TestGetTag(c *gocheck.C) {
 	tags[0]["authorName"] = "doge"
 	tags[0]["authorEmail"] = "<much@email.com>"
 	tags[0]["subject"] = "will bark"
+	links := map[string]string{}
+	links["zipArchive"] = repository.GetArchiveUrl("repo", "0.1", "zip")
+	links["tarArchive"] = repository.GetArchiveUrl("repo", "0.1", "tar.gz")
+	tags[0]["_links"] = links
 	mockRetriever := repository.MockContentRetriever{
 		Refs: tags,
 	}
@@ -1070,7 +1081,7 @@ func (s *S) TestGetTag(c *gocheck.C) {
 	recorder := httptest.NewRecorder()
 	GetTag(recorder, request)
 	c.Assert(recorder.Code, gocheck.Equals, http.StatusOK)
-	var obj []map[string]string
+	var obj []map[string]interface{}
 	json.Unmarshal(recorder.Body.Bytes(), &obj)
 	c.Assert(len(obj), gocheck.Equals, 1)
 	c.Assert(obj[0]["ref"], gocheck.Equals, tags[0]["ref"])
@@ -1080,4 +1091,7 @@ func (s *S) TestGetTag(c *gocheck.C) {
 	c.Assert(obj[0]["authorName"], gocheck.Equals, tags[0]["authorName"])
 	c.Assert(obj[0]["authorEmail"], gocheck.Equals, tags[0]["authorEmail"])
 	c.Assert(obj[0]["subject"], gocheck.Equals, tags[0]["subject"])
+	objLinks := obj[0]["_links"].(map[string]interface{})
+	c.Assert(objLinks["zipArchive"], gocheck.Equals, links["zipArchive"])
+	c.Assert(objLinks["tarArchive"], gocheck.Equals, links["tarArchive"])
 }

--- a/repository/mocks.go
+++ b/repository/mocks.go
@@ -19,7 +19,7 @@ type MockContentRetriever struct {
 	LastPath       string
 	ResultContents []byte
 	Tree           []map[string]string
-	Refs           []map[string]string
+	Refs           []map[string]interface{}
 	LookPathError  error
 	OutputError    error
 }
@@ -251,7 +251,7 @@ func (r *MockContentRetriever) GetTree(repo, ref, path string) ([]map[string]str
 	return r.Tree, nil
 }
 
-func (r *MockContentRetriever) GetForEachRef(repo, pattern string) ([]map[string]string, error) {
+func (r *MockContentRetriever) GetForEachRef(repo, pattern string) ([]map[string]interface{}, error) {
 	if r.LookPathError != nil {
 		return nil, r.LookPathError
 	}
@@ -261,7 +261,7 @@ func (r *MockContentRetriever) GetForEachRef(repo, pattern string) ([]map[string
 	return r.Refs, nil
 }
 
-func (r *MockContentRetriever) GetBranch(repo string) ([]map[string]string, error) {
+func (r *MockContentRetriever) GetBranch(repo string) ([]map[string]interface{}, error) {
 	if r.LookPathError != nil {
 		return nil, r.LookPathError
 	}
@@ -281,7 +281,7 @@ func (r *MockContentRetriever) GetDiff(repo, previousCommit, lastCommit string) 
 	return r.ResultContents, nil
 }
 
-func (r *MockContentRetriever) GetTag(repo string) ([]map[string]string, error) {
+func (r *MockContentRetriever) GetTag(repo string) ([]map[string]interface{}, error) {
 	if r.LookPathError != nil {
 		return nil, r.LookPathError
 	}

--- a/repository/repository_test.go
+++ b/repository/repository_test.go
@@ -833,6 +833,9 @@ func (s *S) TestGetBranchIntegration(c *gocheck.C) {
 	c.Assert(branches[0]["authorName"], gocheck.Equals, "doge")
 	c.Assert(branches[0]["authorEmail"], gocheck.Equals, "<much@email.com>")
 	c.Assert(branches[0]["subject"], gocheck.Equals, "will bark")
+	links := branches[0]["_links"].(map[string]string)
+	c.Assert(links["zipArchive"], gocheck.Equals, GetArchiveUrl(repo, "doge_barks", "zip"))
+	c.Assert(links["tarArchive"], gocheck.Equals, GetArchiveUrl(repo, "doge_barks", "tar.gz"))
 	c.Assert(branches[1]["ref"], gocheck.Matches, "[a-f0-9]{40}")
 	c.Assert(branches[1]["name"], gocheck.Equals, "doge_bites")
 	c.Assert(branches[1]["commiterName"], gocheck.Equals, "doge")
@@ -840,6 +843,9 @@ func (s *S) TestGetBranchIntegration(c *gocheck.C) {
 	c.Assert(branches[1]["authorName"], gocheck.Equals, "doge")
 	c.Assert(branches[1]["authorEmail"], gocheck.Equals, "<much@email.com>")
 	c.Assert(branches[1]["subject"], gocheck.Equals, "will bark")
+	links = branches[1]["_links"].(map[string]string)
+	c.Assert(links["zipArchive"], gocheck.Equals, GetArchiveUrl(repo, "doge_bites", "zip"))
+	c.Assert(links["tarArchive"], gocheck.Equals, GetArchiveUrl(repo, "doge_bites", "tar.gz"))
 	c.Assert(branches[2]["ref"], gocheck.Matches, "[a-f0-9]{40}")
 	c.Assert(branches[2]["name"], gocheck.Equals, "master")
 	c.Assert(branches[2]["commiterName"], gocheck.Equals, "doge")
@@ -847,6 +853,9 @@ func (s *S) TestGetBranchIntegration(c *gocheck.C) {
 	c.Assert(branches[2]["authorName"], gocheck.Equals, "doge")
 	c.Assert(branches[2]["authorEmail"], gocheck.Equals, "<much@email.com>")
 	c.Assert(branches[2]["subject"], gocheck.Equals, "will bark")
+	links = branches[2]["_links"].(map[string]string)
+	c.Assert(links["zipArchive"], gocheck.Equals, GetArchiveUrl(repo, "master", "zip"))
+	c.Assert(links["tarArchive"], gocheck.Equals, GetArchiveUrl(repo, "master", "tar.gz"))
 }
 
 func (s *S) TestGetForEachRefIntegrationWithSubjectEmpty(c *gocheck.C) {
@@ -930,7 +939,8 @@ func (s *S) TestGetForEachRefIntegrationWhenPatternEmpty(c *gocheck.C) {
 	refs, err := GetForEachRef("gandalf-test-repo", "")
 	c.Assert(err, gocheck.IsNil)
 	c.Assert(refs, gocheck.HasLen, 1)
-	c.Assert(refs[0], gocheck.HasLen, 9)
+	c.Assert(refs[0], gocheck.HasLen, 10)
+	c.Assert(refs[0]["_links"], gocheck.HasLen, 2)
 }
 
 func (s *S) TestGetForEachRefIntegrationWhenPatternNonExistent(c *gocheck.C) {
@@ -1094,6 +1104,9 @@ func (s *S) TestGetTagIntegration(c *gocheck.C) {
 	c.Assert(tags[0]["authorName"], gocheck.Equals, "doge")
 	c.Assert(tags[0]["authorEmail"], gocheck.Equals, "<much@email.com>")
 	c.Assert(tags[0]["subject"], gocheck.Equals, "much WOW")
+	links := tags[0]["_links"].(map[string]string)
+	c.Assert(links["zipArchive"], gocheck.Equals, GetArchiveUrl(repo, "0.1", "zip"))
+	c.Assert(links["tarArchive"], gocheck.Equals, GetArchiveUrl(repo, "0.1", "tar.gz"))
 	c.Assert(tags[1]["ref"], gocheck.Matches, "[a-f0-9]{40}")
 	c.Assert(tags[1]["name"], gocheck.Equals, "0.2")
 	c.Assert(tags[1]["commiterName"], gocheck.Equals, "doge")
@@ -1101,4 +1114,12 @@ func (s *S) TestGetTagIntegration(c *gocheck.C) {
 	c.Assert(tags[1]["authorName"], gocheck.Equals, "doge")
 	c.Assert(tags[1]["authorEmail"], gocheck.Equals, "<much@email.com>")
 	c.Assert(tags[1]["subject"], gocheck.Equals, "")
+	links = tags[1]["_links"].(map[string]string)
+	c.Assert(links["zipArchive"], gocheck.Equals, GetArchiveUrl(repo, "0.2", "zip"))
+	c.Assert(links["tarArchive"], gocheck.Equals, GetArchiveUrl(repo, "0.2", "tar.gz"))
+}
+
+func (s *S) TestGetArchiveUrl(c *gocheck.C) {
+	url := GetArchiveUrl("repo", "ref", "zip")
+	c.Assert(url, gocheck.Equals, fmt.Sprintf("/repository/%s/archive/%s.%s", "repo", "ref", "zip"))
 }


### PR DESCRIPTION
This changes add support for ref and format parameters with "." (dot) for archive route.
It is necessary because Pat router does not use routes as regex.

IE:
- old format: http://my-server/repository/repo-name/archive/0.1.0.tar.gz
- new format: http://my-server/repository/repo-name/archive?ref=0.1.0&format=tar.gz
