### PR TITLE
Set `repository:tempDir` as not mandatory (re #140)

### DIFF
--- a/repository/repository.go
+++ b/repository/repository.go
@@ -26,13 +26,8 @@ import (
 var tempDir string
 
 func tempDirLocation() string {
-	if tempDir != "" {
-		return tempDir
-	}
-	var err error
-	tempDir, err = config.GetString("repository:tempDir")
-	if err != nil {
-		panic("You should configure a repository:tempDir for gandalf.")
+	if tempDir == "" {
+		tempDir, _ = config.GetString("repository:tempDir")
 	}
 	return tempDir
 }

--- a/repository/repository_test.go
+++ b/repository/repository_test.go
@@ -70,6 +70,16 @@ func (s *S) TestTempDirLocationDontResetTempDir(c *gocheck.C) {
 	c.Assert(tempDirLocation(), gocheck.Equals, "/var/folders")
 }
 
+func (s *S) TestTempDirLocationWhenNotInGandalfConf(c *gocheck.C) {
+	config.Unset("repository:tempDir")
+	oldTempDir := tempDir
+	tempDir = ""
+	defer func() {
+		tempDir = oldTempDir
+	}()
+	c.Assert(tempDirLocation(), gocheck.Equals, "")
+}
+
 func (s *S) TestNewShouldCreateANewRepository(c *gocheck.C) {
 	tmpdir, err := commandmocker.Add("git", "$*")
 	c.Assert(err, gocheck.IsNil)


### PR DESCRIPTION
Set `repository:tempDir` as a non-mandatory config variable
