### PR TITLE
Support read-only access to repositories

### DIFF
--- a/bin/gandalf.go
+++ b/bin/gandalf.go
@@ -43,6 +43,11 @@ func hasReadPermission(u *user.User, r *repository.Repository) (allowed bool) {
 			return true
 		}
 	}
+	for _, userName := range r.ReadOnlyUsers {
+		if u.Name == userName {
+			return true
+		}
+	}
 	return false
 }
 

--- a/bin/gandalf_test.go
+++ b/bin/gandalf_test.go
@@ -81,6 +81,18 @@ func (s *S) TestHasReadPermissionShouldReturnTrueWhenRepositoryIsPublic(c *goche
 	c.Assert(allowed, gocheck.Equals, true)
 }
 
+func (s *S) TestHasReadPermissionShouldReturnTrueWhenRepositoryIsNotPublicAndUserHasPermissionToRead(c *gocheck.C) {
+	user, err := user.New("readonlyuser", map[string]string{})
+	c.Check(err, gocheck.IsNil)
+	repo := &repository.Repository{
+		Name:          "otherapp",
+		Users:         []string{s.user.Name},
+		ReadOnlyUsers: []string{user.Name},
+	}
+	allowed := hasReadPermission(user, repo)
+	c.Assert(allowed, gocheck.Equals, true)
+}
+
 func (s *S) TestHasReadPermissionShouldReturnTrueWhenRepositoryIsNotPublicAndUserHasPermissionToReadAndWrite(c *gocheck.C) {
 	allowed := hasReadPermission(s.user, s.repo)
 	c.Assert(allowed, gocheck.Equals, true)

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -30,6 +30,17 @@ Repository creation
 
 Creates a repository in the database and an equivalent bare repository in the filesystem.
 
+* Method: POST
+* URI: /repository
+* Format: JSON
+
+Example URL (http://gandalf-server omitted for clarity)::
+
+    $ curl -XPOST /repository \                  # POST to /repository
+        -d '{"name": "myrepository", \           # Name of the repository
+            "users": ["myuser"], \               # Users with read/write access
+            "readonlyusers": ["alice", "bob"]}'  # Users with read-only access
+
 Repository removal
 ------------------
 
@@ -43,12 +54,38 @@ Retrieves information about a repository.
 Access grant in repository
 --------------------------
 
-Grants a user read and write access into a repository.
+Grants a user read and write access into a repository. Specify ``readonly=yes`` if you'd like to grant read-only access.
+
+* Method: POST
+* URI: /repository/grant
+* Format: JSON
+
+Example URL for **read/write** access (http://gandalf-server omitted for clarity)::
+
+    $ curl -XPOST /repository/grant \               # POST to /repository/grant
+        -d '{"repositories": ["myrepo"], \          # Collection of repositories
+            "users": ["john", "james"]}'            # Users with read/write access
+
+Example URL for **read-only** access (http://gandalf-server omitted for clarity)::
+
+    $ curl -XPOST /repository/grant?readonly=yes \  # POST to /repository/grant
+        -d '{"repositories": ["myrepo"], \          # Collection of repositories
+            "users": ["bob", "alice"]}'             # Users with read-only access
 
 Access revoke in repository
 ---------------------------
 
-Revokes a user read and write access from a repository.
+Revokes a user both read **and** write access from a repository.
+
+* Method: DELETE
+* URI: /repository/revoke
+* Format: JSON
+
+Example URL (http://gandalf-server omitted for clarity)::
+
+    $ curl -XDELETE /repository/revoke \            # DELETE to /repository/grant
+        -d '{"repositories": ["myrepo"], \          # Collection of repositories
+            "users": ["john", "james"]}'            # Users with read-only access
 
 Get file contents
 -----------------
@@ -356,7 +393,8 @@ Gandalf supports namespaces for repositories and must be informed in the name of
 
         $ curl -XPOST /repository \
             -d '{"name": "mynamespace/myrepository", \
-                "users": ["myuser"]}'
+                "users": ["myuser"], \
+                "readonlyusers": ["alice", "bob"]}'
 
 * Returns a list of all the branches of the specified `mynamespace/myrepository`.
 


### PR DESCRIPTION
Regarding the repository.Repository struct:
- `Repository.Users`: users that with write access
- `Repository.ReadOnlyUsers`: users with read-only access

Implementation notes:
- When creating a new repository specify which users should be
  allowed read access
- Allow specifying if read-only access when adding user to repo
- When removing user from repo, remove from both write and read
  collections of users

Please review, comment, suggest and advise! :wink: 
