### PR TITLE
Fix test that fails sometimes b/c of timing

### DIFF
--- a/repository/repository_test.go
+++ b/repository/repository_test.go
@@ -2197,7 +2197,7 @@ func (s *S) TestGetLogsWithAllSortsOfSubjects(c *gocheck.C) {
 	c.Assert(history.Commits[1].Author.Name, gocheck.Equals, "doge")
 	c.Assert(history.Commits[1].Author.Email, gocheck.Equals, "much@email.com")
 	c.Assert(history.Commits[1].Subject, gocheck.Equals, "will\tbark")
-	c.Assert(history.Commits[1].CreatedAt, gocheck.Equals, history.Commits[0].Author.Date)
+	c.Assert(history.Commits[1].CreatedAt, gocheck.Equals, history.Commits[1].Author.Date)
 	c.Assert(history.Commits[2].Ref, gocheck.Matches, "[a-f0-9]{40}")
 	c.Assert(history.Commits[2].Parent, gocheck.HasLen, 0)
 	c.Assert(history.Commits[2].Committer.Name, gocheck.Equals, "doge")
@@ -2205,7 +2205,7 @@ func (s *S) TestGetLogsWithAllSortsOfSubjects(c *gocheck.C) {
 	c.Assert(history.Commits[2].Author.Name, gocheck.Equals, "doge")
 	c.Assert(history.Commits[2].Author.Email, gocheck.Equals, "much@email.com")
 	c.Assert(history.Commits[2].Subject, gocheck.Equals, "")
-	c.Assert(history.Commits[2].CreatedAt, gocheck.Equals, history.Commits[0].Author.Date)
+	c.Assert(history.Commits[2].CreatedAt, gocheck.Equals, history.Commits[2].Author.Date)
 	c.Assert(history.Next, gocheck.Equals, "")
 }
 


### PR DESCRIPTION
If the computer is slow or you are unlucky, one of the tests can fail, because
the first and third commits can happen on a different second. This fixes that.
Here's an example of the failure that it fixes:

    [marca@marca-mac2 gandalf]$ go test ./repository

    ----------------------------------------------------------------------
    FAIL: repository_test.go:2163: S.TestGetLogsWithAllSortsOfSubjects

    repository_test.go:2202:
        c.Assert(history.Commits[1].CreatedAt, gocheck.Equals, history.Commits[0].Author.Date)
    ... obtained string = "Fri Jan 2 09:21:20 2015 -0800"
    ... expected string = "Fri Jan 2 09:21:21 2015 -0800"

    OOPS: 116 passed, 1 FAILED
    --- FAIL: Test (8.30s)
    FAIL
    FAIL    github.com/tsuru/gandalf/repository     8.307s