### PR TITLE
Better error when can't open config file

### DIFF
--- a/webserver/main.go
+++ b/webserver/main.go
@@ -25,12 +25,15 @@ func main() {
 		fmt.Printf("gandalf-webserver version %s\n", version)
 		return
 	}
+	log.Printf("Opening config file: %s ...\n", *configFile)
 	err := config.ReadAndWatchConfigFile(*configFile)
 	if err != nil {
-		msg := `Could not find gandalf config file. Searched on %s.
-For an example conf check gandalf/etc/gandalf.conf file.\n %s`
-		log.Panicf(msg, *configFile, err)
+		msg := `Could not open gandalf config file at %s (%s).
+  For an example, see: gandalf/etc/gandalf.conf
+  Note that you can specify a different config file with the --config option -- e.g.: --config=./etc/gandalf.conf`
+		log.Fatalf(msg, *configFile, err)
 	}
+	log.Printf("Successfully read config file: %s\n", *configFile)
 	router := api.SetupRouter()
 	bind, err := config.GetString("bind")
 	if err != nil {


### PR DESCRIPTION
Also log when opening config file.

Before:

    [marca@marca-mac2 gandalf]$ go run webserver/main.go
    2015/01/02 10:31:12 Could not find gandalf config file. Searched on /etc/gandalf.conf.
    For an example conf check gandalf/etc/gandalf.conf file.\n open /etc/gandalf.conf: no such file or directory
    panic: Could not find gandalf config file. Searched on /etc/gandalf.conf.
    For an example conf check gandalf/etc/gandalf.conf file.\n open /etc/gandalf.conf: no such file or directory

    goroutine 1 [running]:
    log.Panicf(0x50b9d0, 0x71, 0xc20807bf70, 0x2, 0x2)
            /usr/local/Cellar/go/1.4/libexec/src/log/log.go:314 +0xd0
    main.main()
            /Users/marca/go/src/github.com/tsuru/gandalf/webserver/main.go:32 +0x3ab

    goroutine 6 [chan receive]:
    github.com/tsuru/tsuru/db/storage.retire(0xc20804e140)
            /Users/marca/go/src/github.com/tsuru/tsuru/db/storage/storage.go:111 +0x7f
    created by github.com/tsuru/tsuru/db/storage.init·1
            /Users/marca/go/src/github.com/tsuru/tsuru/db/storage/storage.go:106 +0x61
    exit status 2

After:

    [marca@marca-mac2 gandalf]$ go run webserver/main.go
    2015/01/02 10:31:29 Opening config file: /etc/gandalf.conf ...
    2015/01/02 10:31:29 Could not open gandalf config file at /etc/gandalf.conf (open /etc/gandalf.conf: no such file or directory).
      For an example, see: gandalf/etc/gandalf.conf
    exit status 1