### PR TITLE
Log ip/port gandalf is listening on

### DIFF
--- a/webserver/main.go
+++ b/webserver/main.go
@@ -41,6 +41,12 @@ For an example conf check gandalf/etc/gandalf.conf file.\n %s`
 		}
 	}
 	if !*dry {
+		bareLocation, err := config.GetString("git:bare:location")
+		if err != nil {
+			panic("You should configure a git:bare:location for gandalf.")
+		}
+		log.Printf("Repository location: %s\n", bareLocation)
+		log.Printf("gandalf-webserver %s listening on %s\n", version, bind)
 		log.Fatal(http.ListenAndServe(bind, router))
 	}
 }


### PR DESCRIPTION
Before, gandalf was disturbingly silent when it ran. It's nice to give some feedback and to tell the user the IP and port that it's listening on.

Before:

    [marca@marca-mac2 gandalf]$ go run webserver/main.go --config=./etc/gandalf.conf
    ^Cexit status 2

After:

    [marca@marca-mac2 gandalf]$ go run webserver/main.go --config=./etc/gandalf.conf
    2015/01/02 17:42:58 Repository location: /var/lib/gandalf/repositories
    2015/01/02 17:42:58 gandalf-webserver 0.5.2 listening on localhost:8000
    ^Cexit status 2