### PR TITLE
Include more info in /healthcheck

### DIFF
--- a/api/handler.go
+++ b/api/handler.go
@@ -12,6 +12,7 @@ import (
 	"io/ioutil"
 	"mime"
 	"net/http"
+	"os"
 	"path/filepath"
 	"reflect"
 	"strconv"
@@ -308,6 +309,16 @@ func parseBody(body io.ReadCloser, result interface{}) error {
 }
 
 func healthCheck(w http.ResponseWriter, r *http.Request) {
+	dburl, _ := config.GetString("database:url")
+	if dburl == "" {
+		dburl = db.DefaultDatabaseURL
+	}
+	dbname, _ := config.GetString("database:name")
+	if dbname == "" {
+		dbname = db.DefaultDatabaseName
+	}
+	bareLocation, _ := config.GetString("git:bare:location")
+	bareTemplate, _ := config.GetString("git:bare:template")
 	conn, err := db.Conn()
 	if err != nil {
 		return
@@ -318,7 +329,21 @@ func healthCheck(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, "Failed to ping the database: %s\n", err)
 		return
 	}
-	w.Write([]byte("WORKING"))
+	result := make(map[string]interface{})
+	database := make(map[string]interface{})
+	database["url"] = dburl
+	database["name"] = dbname
+	git := make(map[string]interface{})
+	git["bare_location"] = bareLocation
+	git["bare_template"] = bareTemplate
+	result["database"] = database
+	result["git"] = git
+	result["pid"] = os.Getpid()
+	result["uid"] = os.Getuid()
+	result["status"] = "OK"
+	w.Header().Set("Content-Type", "application/json")
+	b, err := json.Marshal(result)
+	w.Write(b)
 }
 
 func getMimeType(path string, content []byte) string {

--- a/api/handler.go
+++ b/api/handler.go
@@ -334,6 +334,10 @@ func healthCheck(w http.ResponseWriter, r *http.Request) {
 	database["url"] = dburl
 	database["name"] = dbname
 	git := make(map[string]interface{})
+	gitVersion, err := repository.GitVersion()
+	if err == nil && gitVersion != "" {
+		git["version"] = gitVersion
+	}
 	git["bare_location"] = bareLocation
 	git["bare_template"] = bareTemplate
 	result["database"] = database

--- a/repository/git.go
+++ b/repository/git.go
@@ -5,13 +5,27 @@
 package repository
 
 import (
+	"bytes"
 	"fmt"
+	"os"
 	"os/exec"
 	"path"
+	"strings"
 
 	"github.com/tsuru/config"
 	"github.com/tsuru/gandalf/fs"
 )
+
+func GitVersion() (string, error) {
+	cmd := exec.Command("git", "version")
+	cmd.Stdin = os.Stdin
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+	err := cmd.Run()
+	return strings.TrimSpace(stdout.String()), err
+}
 
 var bare string
 


### PR DESCRIPTION
Before:

    [marca@marca-mac2 ~]$ http http://127.0.0.1:8000/healthcheck
    HTTP/1.1 200 OK
    Content-Length: 7
    Content-Type: text/plain; charset=utf-8
    Date: Sat, 03 Jan 2015 07:40:52 GMT

    WORKING

After:

    [marca@marca-mac2 ~]$ http http://127.0.0.1:8000/healthcheck
    HTTP/1.1 200 OK
    Content-Length: 189
    Content-Type: application/json
    Date: Sat, 03 Jan 2015 07:39:04 GMT

    {
        "database": {
            "name": "gandalf",
            "url": "127.0.0.1:27017"
        },
        "git": {
            "bare_location": "/var/lib/gandalf/repositories",
            "bare_template": "/home/git/bare-template"
        },
        "pid": 75611,
        "status": "OK",
        "uid": 502
    }