### PR TITLE
Log requests to stdout like tsr does

### DIFF
--- a/api/middleware.go
+++ b/api/middleware.go
@@ -1,0 +1,33 @@
+// Copyright 2014 gandalf authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package api
+
+import (
+	"log"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/codegangsta/negroni"
+)
+
+type loggerMiddleware struct {
+	logger *log.Logger
+}
+
+func NewLoggerMiddleware() *loggerMiddleware {
+	return &loggerMiddleware{
+		logger: log.New(os.Stdout, "", 0),
+	}
+}
+
+func (l *loggerMiddleware) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+	start := time.Now()
+	next(rw, r)
+	duration := time.Since(start)
+	res := rw.(negroni.ResponseWriter)
+	nowFormatted := time.Now().Format(time.RFC3339Nano)
+	l.logger.Printf("%s %s %s %d in %0.6fms", nowFormatted, r.Method, r.URL.Path, res.Status(), float64(duration)/float64(time.Millisecond))
+}

--- a/webserver/main.go
+++ b/webserver/main.go
@@ -10,6 +10,7 @@ import (
 	"log"
 	"net/http"
 
+	"github.com/codegangsta/negroni"
 	"github.com/tsuru/config"
 	"github.com/tsuru/gandalf/api"
 )
@@ -32,6 +33,9 @@ For an example conf check gandalf/etc/gandalf.conf file.\n %s`
 		log.Panicf(msg, *configFile, err)
 	}
 	router := api.SetupRouter()
+	n := negroni.New()
+	n.Use(api.NewLoggerMiddleware())
+	n.UseHandler(router)
 	bind, err := config.GetString("bind")
 	if err != nil {
 		var perr error
@@ -41,6 +45,6 @@ For an example conf check gandalf/etc/gandalf.conf file.\n %s`
 		}
 	}
 	if !*dry {
-		log.Fatal(http.ListenAndServe(bind, router))
+		log.Fatal(http.ListenAndServe(bind, n))
 	}
 }


### PR DESCRIPTION
This matches the behavior of tsuru and makes it nicer to see that stuff is happening.

Looks like this (also includes change from #175):

    [marca@marca-mac2 gandalf]$ build/gandalf-webserver
    2015/01/03 07:51:45 Repository location: /var/lib/gandalf/repositories
    2015/01/03 07:51:45 gandalf-webserver 0.5.2 listening on localhost:8000
    2015-01-03T07:51:50.202073755-08:00 GET /healthcheck/ 200 in 1.226190ms
    2015-01-03T07:51:51.507294871-08:00 GET /healthcheck/ 200 in 0.303232ms
    2015-01-03T07:51:55.847606748-08:00 GET /foo 404 in 0.038948ms
    2015-01-03T07:52:01.078417649-08:00 GET /user/jack 404 in 0.075090ms
    2015-01-03T07:52:06.699418382-08:00 GET /tet 404 in 0.035216ms
    2015-01-03T07:52:11.781836649-08:00 GET /healthcheck/ 200 in 0.720851ms