### PR TITLE
License: Fixed copyright year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2015, gandalf Authors. All rights reserved.
+Copyright (c) 2013-2015, gandalf Authors. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/bin/gandalf.go
+++ b/bin/gandalf.go
@@ -1,4 +1,4 @@
-// Copyright 2015 gandalf authors. All rights reserved.
+// Copyright 2014 gandalf authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 


### PR DESCRIPTION
The year in a copyright statement normally shows a date of first publishing. So, the best way is to use a range of dates.