### PR TITLE
Support annotated tags

### DIFF
--- a/api/handler_test.go
+++ b/api/handler_test.go
@@ -1632,13 +1632,13 @@ func (s *S) TestPostNewCommit(c *check.C) {
 			Ref:       "some-random-ref",
 			Name:      "master",
 			CreatedAt: "Mon Jul 28 10:13:27 2014 -0300",
-			Committer: &repository.GitUser{
-				Name:  params["committer-name"],
-				Email: params["committer-email"],
-			},
 			Author: &repository.GitUser{
 				Name:  params["author-name"],
 				Email: params["author-email"],
+			},
+			Committer: &repository.GitUser{
+				Name:  params["committer-name"],
+				Email: params["committer-email"],
 			},
 			Subject: params["message"],
 			Links: &repository.Links{

--- a/api/handler_test.go
+++ b/api/handler_test.go
@@ -1674,6 +1674,7 @@ func (s *S) TestPostNewCommit(c *check.C) {
 			"email": "doge@much.com",
 			"date":  "",
 		},
+		"tagger": nil,
 		"_links": map[string]interface{}{
 			"tarArchive": "/repository/repo/archive?ref=master\u0026format=tar.gz",
 			"zipArchive": "/repository/repo/archive?ref=master\u0026format=zip",

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -211,7 +211,7 @@ Example result::
         author: {
             name: "Author name",
             email: "<author@email.com>",
-            date: "Mon Jul 28 10:13:27 2014 -0300""
+            date: "Mon Jul 28 10:13:27 2014 -0300"
         },
         committer: {
             name: "Committer name",
@@ -251,7 +251,7 @@ Example result::
         author: {
             name: "Author name",
             email: "<author@email.com>",
-            date: "Mon Jul 28 10:13:27 2014 -0300""
+            date: "Mon Jul 28 10:13:27 2014 -0300"
         },
         committer: {
             name: "Committer name",
@@ -361,7 +361,7 @@ Example result::
         author: {
             name: "Author Name",
             email: "<author@email.com>",
-            date: "Mon Jul 28 10:13:27 2014 -0300""
+            date: "Mon Jul 28 10:13:27 2014 -0300"
         },
         committer: {
             name: "Committer Name",
@@ -403,7 +403,7 @@ Example result::
             author: {
                 name: "Author name",
                 email: "<author@email.com>",
-                date: "Mon Jul 28 10:13:27 2014 -0300""
+                date: "Mon Jul 28 10:13:27 2014 -0300"
             },
             committer: {
                 name: "Committer name",

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -218,6 +218,11 @@ Example result::
             email: "<committer@email.com>",
             date: "Tue Jul 29 13:43:57 2014 -0300"
         },
+        tagger: {
+            date: "",
+            email: "",
+            name: ""
+        },
         _links: {
             zipArchive: "/repository/myrepository/branch/archive?ref=master&format=zip",
             tarArchive: "/repository/myrepository/branch/archive?ref=master&format=tar.gz"
@@ -258,9 +263,42 @@ Example result::
             email: "<committer@email.com>",
             date: "Tue Jul 29 13:43:57 2014 -0300"
         },
+        tagger: {
+            name: "",
+            email: "",
+            date: ""
+        },
         _links: {
             zipArchive: "/repository/myrepository/branch/archive?ref=0.1&format=zip",
             tarArchive: "/repository/myrepository/branch/archive?ref=0.1&format=tar.gz"
+        }
+    }]
+
+Example result for an `annotated tag <https://git-scm.com/book/en/v2/Git-Basics-Tagging#Annotated-Tags>`_::
+
+    [{
+        ref: "6767b5de5943632e47cb6f8bf5b2147bc0be5cf8",
+        name: "0.2",
+        subject: "much WOW",
+        createdAt: "Tue Jul 29 13:43:57 2014 -0300"
+        author: {
+            name: "",
+            email: "",
+            date: ""
+        },
+        committer: {
+            name: "",
+            email: "",
+            date: ""
+        },
+        tagger: {
+            name: "Tagger name",
+            email: "<tagger@email.com>",
+            date: "Tue Jul 29 13:43:57 2014 -0300"
+        },
+        _links: {
+            zipArchive: "/repository/myrepository/branch/archive?ref=0.2&format=zip",
+            tarArchive: "/repository/myrepository/branch/archive?ref=0.2&format=tar.gz"
         }
     }]
 
@@ -367,6 +405,11 @@ Example result::
             name: "Committer Name",
             email: "<committer@email.com>",
             date: "Tue Jul 29 13:43:57 2014 -0300"
+        },
+        tagger: {
+            date: "",
+            email: "",
+            name: ""
         },
         _links: {
             tarArchive: "/repository/myrepository/archive?ref=master&format=tar.gz",

--- a/repository/mocks.go
+++ b/repository/mocks.go
@@ -337,16 +337,6 @@ func (r *MockContentRetriever) TempClone(repo string) (string, func(), error) {
 	return r.ClonePath, r.CleanUp, nil
 }
 
-func (r *MockContentRetriever) SetCommitter(cloneDir string, committer GitUser) error {
-	if r.LookPathError != nil {
-		return r.LookPathError
-	}
-	if r.OutputError != nil {
-		return r.OutputError
-	}
-	return nil
-}
-
 func (r *MockContentRetriever) Checkout(cloneDir, branch string, isNew bool) error {
 	if r.LookPathError != nil {
 		return r.LookPathError
@@ -367,7 +357,7 @@ func (r *MockContentRetriever) AddAll(cloneDir string) error {
 	return nil
 }
 
-func (r *MockContentRetriever) Commit(cloneDir, message string, author GitUser) error {
+func (r *MockContentRetriever) Commit(cloneDir, message string, author, committer GitUser) error {
 	if r.LookPathError != nil {
 		return r.LookPathError
 	}

--- a/repository/mocks.go
+++ b/repository/mocks.go
@@ -103,6 +103,16 @@ func MakeCommit(testPath, content string) error {
 	return cmd.Run()
 }
 
+func PushTags(testPath string) error {
+	gitPath, err := exec.LookPath("git")
+	if err != nil {
+		return err
+	}
+	cmd := exec.Command(gitPath, "push", "--tags")
+	cmd.Dir = testPath
+	return cmd.Run()
+}
+
 func CreateCommit(tmpPath, repo, file, content string) error {
 	testPath := path.Join(tmpPath, repo+".git")
 	err := CreateFile(testPath, file, content)
@@ -271,6 +281,20 @@ func CreateTag(testPath, tagname string) error {
 		return err
 	}
 	cmd := exec.Command(gitPath, "tag", tagname)
+	cmd.Dir = testPath
+	return cmd.Run()
+}
+
+func CreateAnnotatedTag(testPath, tagname, message string, tagger GitUser) error {
+	gitPath, err := exec.LookPath("git")
+	if err != nil {
+		return err
+	}
+	cmd := exec.Command(gitPath, "tag", "-a", tagname, "-m", message)
+	env := os.Environ()
+	env = append(env, fmt.Sprintf("GIT_COMMITTER_NAME=%s", tagger.Name))
+	env = append(env, fmt.Sprintf("GIT_COMMITTER_EMAIL=%s", tagger.Email))
+	cmd.Env = env
 	cmd.Dir = testPath
 	return cmd.Run()
 }

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -528,7 +528,8 @@ func (*GitContentRetriever) GetForEachRef(repo, pattern string) ([]Ref, error) {
 			authorDate = fields[7]
 			subject = strings.Join(fields[8:], "\t") // let there be subjects with \t
 		} else {
-			return nil, fmt.Errorf("Error when trying to obtain the refs of repository %s (Invalid git for-each-ref output [%s]).", repo, out)
+			log.Errorf("Could not match required ref elements for %s (invalid git input: %s).", repo, line)
+			continue
 		}
 		object := Ref{}
 		object.Ref = ref
@@ -552,7 +553,7 @@ func (*GitContentRetriever) GetForEachRef(repo, pattern string) ([]Ref, error) {
 		objects[objectCount] = object
 		objectCount++
 	}
-	return objects, nil
+	return objects[0:objectCount], nil
 }
 
 func (*GitContentRetriever) GetBranches(repo string) ([]Ref, error) {

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -505,7 +505,7 @@ func (*GitContentRetriever) GetForEachRef(repo, pattern string) ([]Ref, error) {
 	if err != nil {
 		return nil, fmt.Errorf("Error when trying to obtain the refs of repository %s (%s).", repo, err)
 	}
-	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
+	lines := strings.Split(strings.TrimSuffix(string(out), "\n"), "\n")
 	objectCount := len(lines)
 	if len(lines) == 1 && len(lines[0]) == 0 {
 		objectCount = 0

--- a/repository/repository_test.go
+++ b/repository/repository_test.go
@@ -1373,8 +1373,9 @@ func (s *S) TestGetForEachRefOutputInvalid(c *check.C) {
 	tmpdir, err := commandmocker.Add("git", "-")
 	c.Assert(err, check.IsNil)
 	defer commandmocker.Remove(tmpdir)
-	_, err = GetForEachRef(repo, "")
-	c.Assert(err.Error(), check.Equals, "Error when trying to obtain the refs of repository gandalf-test-repo (Invalid git for-each-ref output [-]).")
+	refs, err := GetForEachRef(repo, "")
+	c.Assert(err, check.IsNil)
+	c.Assert(refs, check.HasLen, 0)
 }
 
 func (s *S) TestGetForEachRefOutputEmpty(c *check.C) {

--- a/repository/repository_test.go
+++ b/repository/repository_test.go
@@ -1338,6 +1338,26 @@ func (s *S) TestGetForEachRefIntegrationWhenPatternInvalid(c *check.C) {
 	c.Assert(err.Error(), check.Equals, "Error when trying to obtain the refs of repository gandalf-test-repo (exit status 129).")
 }
 
+func (s *S) TestGetForEachRefWithSomeEmptyFields(c *check.C) {
+	oldBare := bare
+	bare = "/tmp"
+	repo := "gandalf-test-repo"
+	file := "README"
+	content := "much WOW"
+	cleanUp, errCreate := CreateTestRepository(bare, repo, file, content)
+	defer func() {
+		cleanUp()
+		bare = oldBare
+	}()
+	c.Assert(errCreate, check.IsNil)
+	tmpdir, err := commandmocker.Add("git", "ec083c5f40be15e2bf5a84efe83d8f4723a6dcc0\tmaster\t\t\t\t\t\t\t")
+	c.Assert(err, check.IsNil)
+	defer commandmocker.Remove(tmpdir)
+	refs, err := GetForEachRef(repo, "")
+	c.Assert(err, check.IsNil)
+	c.Assert(refs, check.HasLen, 1)
+}
+
 func (s *S) TestGetForEachRefOutputInvalid(c *check.C) {
 	oldBare := bare
 	bare = "/tmp"


### PR DESCRIPTION
Tags such as the one created with following command are now supported:

```fish
git tag 0.7.2 -m "Annotation for tag 0.7.2"
```

Please review and comment.