### PR TITLE
Fixes repository broken tests

### DIFF
--- a/repository/repository.go
+++ b/repository/repository.go
@@ -497,7 +497,7 @@ func (*GitContentRetriever) GetForEachRef(repo, pattern string) ([]Ref, error) {
 		return nil, fmt.Errorf("Error when trying to obtain the refs of repository %s (Repository does not exist).", repo)
 	}
 	format := "%(objectname)%09%(refname:short)%09%(committername)%09%(committeremail)%09%(committerdate)%09%(authorname)%09%(authoremail)%09%(authordate)%09%(taggername)%09%(taggeremail)%09%(taggerdate)%09%(contents:subject)"
-	cmd := exec.Command(gitPath, "for-each-ref", "--sort=-committerdate", "--format", format)
+	cmd := exec.Command(gitPath, "for-each-ref", "--sort=-committerdate", "--sort=refname", "--format", format)
 	if len(pattern) > 0 {
 		cmd.Args = append(cmd.Args, pattern)
 	}

--- a/repository/repository_test.go
+++ b/repository/repository_test.go
@@ -1563,10 +1563,10 @@ func (s *S) TestGetTagsAnnotatedTag(c *check.C) {
 	tags, err := GetTags(repo)
 	c.Assert(err, check.IsNil)
 	c.Assert(tags, check.HasLen, 4)
-	c.Assert(tags[2].Tagger.Name, check.Equals, user.Name)
-	c.Assert(tags[2].Tagger.Email, check.Equals, "<"+user.Email+">")
-	c.Assert(tags[2].CreatedAt, check.Equals, tags[2].Tagger.Date)
-	c.Assert(tags[2].Subject, check.Equals, "much tag")
+	c.Assert(tags[1].Tagger.Name, check.Equals, user.Name)
+	c.Assert(tags[1].Tagger.Email, check.Equals, "<"+user.Email+">")
+	c.Assert(tags[1].Tagger.Date, check.Equals, tags[1].CreatedAt)
+	c.Assert(tags[1].Subject, check.Equals, "much tag")
 }
 
 func (s *S) TestGetArchiveUrl(c *check.C) {


### PR DESCRIPTION
This PR fix repository broken tests.

git-for-each-ref sort by `committerdate` returns tags in wrong order. 
added a second filter by refname.