### PR TITLE
Fix go vet errors in CI

### DIFF
--- a/bin/gandalf_test.go
+++ b/bin/gandalf_test.go
@@ -82,14 +82,14 @@ func (s *S) TestHasReadPermissionShouldReturnTrueWhenRepositoryIsPublic(c *check
 }
 
 func (s *S) TestHasReadPermissionShouldReturnTrueWhenRepositoryIsNotPublicAndUserHasPermissionToRead(c *check.C) {
-	user, err := user.New("readonlyuser", map[string]string{})
+	readOnlyUser, err := user.New("readonlyuser", map[string]string{})
 	c.Check(err, check.IsNil)
 	repo := &repository.Repository{
 		Name:          "otherapp",
 		Users:         []string{s.user.Name},
-		ReadOnlyUsers: []string{user.Name},
+		ReadOnlyUsers: []string{readOnlyUser.Name},
 	}
-	allowed := hasReadPermission(user, repo)
+	allowed := hasReadPermission(readOnlyUser, repo)
 	c.Assert(allowed, check.Equals, true)
 }
 


### PR DESCRIPTION
```bash
ERROR: go vet failures:

bin/gandalf_test.go:85: declaration of "user" shadows declaration at bin/gandalf_test.go:19
```